### PR TITLE
seeds and complete backwards

### DIFF
--- a/m2t/scraper.py
+++ b/m2t/scraper.py
@@ -70,9 +70,9 @@ def scrape_http(parsed_tracker, hashes):
 	ret = {}
 	for hash, stats in decoded['files'].iteritems():		
 		nice_hash = binascii.b2a_hex(hash)		
-		s = stats["downloaded"]
+		s = stats["complete"]
 		p = stats["incomplete"]
-		c = stats["complete"]
+		c = stats["downloaded"]
 		ret[nice_hash] = { "seeds" : s, "peers" : p, "complete" : c}		
 	return ret
 


### PR DESCRIPTION
At least for the tracker I am using, stats["complete"] and stats["downloaded"] are backwards in scrape_http().
The "complete" key actually signifies how many seeders there are, and the "downloaded" key signifies how many people have downloaded the file, whether or not they are still seeding it.
