### PR TITLE
Python3 and ipv6 support

### DIFF
--- a/m2t/scraper.py
+++ b/m2t/scraper.py
@@ -1,5 +1,7 @@
 import binascii, urllib, socket, random, struct
-from bcode import bdecode
+#from BitTorrent.bencode import bdecode
+from libtorrent import bdecode
+
 from urlparse import urlparse, urlunsplit
 
 def scrape(tracker, hashes):

--- a/m2t/scraper.py
+++ b/m2t/scraper.py
@@ -37,23 +37,27 @@ def scrape_udp(parsed_tracker, hashes):
 	print ("Scraping UDP: %s for %s hashes" % (parsed_tracker.geturl(), len(hashes)))
 	if len(hashes) > 74:
 		raise RuntimeError("Only 74 hashes can be scraped on a UDP tracker due to UDP limitations")
-	transaction_id = "\x00\x00\x04\x12\x27\x10\x19\x70";
-	connection_id = "\x00\x00\x04\x17\x27\x10\x19\x80";
-	sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-	sock.settimeout(8)
-	conn = (socket.gethostbyname(parsed_tracker.hostname), parsed_tracker.port)
-	
-	#Get connection ID
-	req, transaction_id = udp_create_connection_request()
-	sock.sendto(req, conn);
-	buf = sock.recvfrom(2048)[0]
-	connection_id = udp_parse_connection_response(buf, transaction_id)
-	
-	#Scrape away
-	req, transaction_id = udp_create_scrape_request(connection_id, hashes)
-	sock.sendto(req, conn)
-	buf = sock.recvfrom(2048)[0]
-	return udp_parse_scrape_response(buf, transaction_id, hashes)
+
+	for af, socktype, proto, canonname, conn in socket.getaddrinfo(parsed_tracker.hostname, parsed_tracker.port, socket.AF_UNSPEC, socket.SOCK_DGRAM):
+		#print ("trying af",af,"conn",conn)
+		try:
+			sock = socket.socket(af, socktype)
+			sock.settimeout(8)
+
+			#Get connection ID
+			req, transaction_id = udp_create_connection_request()
+			sock.sendto(req, conn);
+			buf = sock.recvfrom(2048)[0]
+			connection_id = udp_parse_connection_response(buf, transaction_id)
+
+			#Scrape away
+			req, transaction_id = udp_create_scrape_request(connection_id, hashes)
+			sock.sendto(req, conn)
+			buf = sock.recvfrom(2048)[0]
+			return udp_parse_scrape_response(buf, transaction_id, hashes)
+		except:
+			continue
+	raise RuntimeError("Failed to scrape UDP tracker")
 
 def scrape_http(parsed_tracker, hashes):
 	print ("Scraping HTTP: %s for %s hashes" % (parsed_tracker.geturl(), len(hashes)))


### PR DESCRIPTION
If you are interested, 

this PR makes `scraper.py` run on newer systems:
- works in python3 now (as python2 is on its way out)
- supports IPv6 in addition to IPv4, including retrying with different protocol if needed
- tested on Debian Buster using existing packages

note that this only fixes `scraper.py` to work in python3 - I did not use the rest of the code which probably also needs upgrading to python3